### PR TITLE
Please make the build reproducible

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -140,7 +140,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand


### PR DESCRIPTION
```
Whilst working on the Reproducible Builds effort [0], we noticed
that tweeny could not be built reproducibly.

This is because the documentation includes the absolute build path.

 [0] https://reproducible-builds.org/
```