### PR TITLE
Remove some extraneous semicolons

### DIFF
--- a/include/tween.tcc
+++ b/include/tween.tcc
@@ -246,7 +246,7 @@ namespace tweeny {
 
     template<typename T, typename... Ts> inline uint16_t tween<T, Ts...>::point() const {
         return currentPoint;
-    };
+    }
 
     template<typename T, typename... Ts> inline uint16_t tween<T, Ts...>::pointAt(float progress) const {
         uint32_t t = static_cast<uint32_t>(progress * total);
@@ -254,7 +254,7 @@ namespace tweeny {
         while (t > points.at(point).stacked) point++;
         if (point > 0 && t <= points.at(point - 1u).stacked) point--;
         return point;
-    };
+    }
 }
 
 #endif //TWEENY_TWEEN_TCC

--- a/include/tweenone.tcc
+++ b/include/tweenone.tcc
@@ -243,6 +243,6 @@ namespace tweeny {
         while (t > points.at(point).stacked) point++;
         if (point > 0 && t <= points.at(point - 1u).stacked) point--;
         return point;
-  };
+    }
 }
 #endif //TWEENY_TWEENONE_TCC


### PR DESCRIPTION
The semicolons I removed cause warnings on GCC's `-Wpedantic` warning level.