### PR TITLE
Fixed installation on other than Ubuntu distributions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,9 @@ target_include_directories(tweeny INTERFACE
 )
 
 # Set up install
+include(GNUInstallDirs)
 install(TARGETS tweeny EXPORT TweenyTargets)
-install(DIRECTORY include/ DESTINATION include/tweeny)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/tweeny)
 
 # Set up export and config
 include(cmake/SetupExports.cmake)

--- a/cmake/SetupExports.cmake
+++ b/cmake/SetupExports.cmake
@@ -24,9 +24,10 @@
 # when installed.
 
 include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 # Setup install of exported targets
-install(EXPORT TweenyTargets DESTINATION lib/cmake/Tweeny)
+install(EXPORT TweenyTargets DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Tweeny)
 
 # Macro to write config
 write_basic_package_version_file(
@@ -41,5 +42,5 @@ install(
         cmake/TweenyConfig.cmake
         "${CMAKE_CURRENT_BINARY_DIR}/TweenyConfigVersion.cmake"
     DESTINATION
-        lib/cmake/Tweeny
+        ${CMAKE_INSTALL_LIBDIR}/cmake/Tweeny
 )


### PR DESCRIPTION
Fixed installation on other than Ubuntu GNU/Linux distributions.

Fedora and other GNU/Linux distributions use different $libdir prefixes. Now it can be installed on any GNU/Linux distributions.