### PR TITLE
Simplify and enhance CMake file in doc/

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,11 +23,6 @@
 # This cmake file creates and builds doxygen documentation. It also sets it in the install list.
 
 find_package(Doxygen)
-if (TWEENY_BUILD_DOCUMENTATION)
-    set(DOC_ADD_TO_ALL ALL)
-else()
-    set(DOC_ADD_TO_ALL "")
-endif()
 
 if(DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
@@ -38,14 +33,12 @@ if(DOXYGEN_FOUND)
          DESTINATION
             ${CMAKE_CURRENT_BINARY_DIR}
     )
-    add_custom_target(doc ${DOC_ADD_TO_ALL}
+    add_custom_target(doc ALL
             ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             COMMENT "Generating API documentation with Doxygen" VERBATIM)
 
-    if (TWEENY_BUILD_DOCUMENTATION)
-        include(GNUInstallDirs)
-        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR})
-    endif()
+    include(GNUInstallDirs)
+    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 endif(DOXYGEN_FOUND)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -44,7 +44,8 @@ if(DOXYGEN_FOUND)
             COMMENT "Generating API documentation with Doxygen" VERBATIM)
 
     if (TWEENY_BUILD_DOCUMENTATION)
-        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION share/doc/Tweeny)
+        include(GNUInstallDirs)
+        install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR})
     endif()
 
 endif(DOXYGEN_FOUND)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -22,23 +22,20 @@
 
 # This cmake file creates and builds doxygen documentation. It also sets it in the install list.
 
-find_package(Doxygen)
+find_package(Doxygen REQUIRED)
 
-if(DOXYGEN_FOUND)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../README.md DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-    file(COPY
-            ${CMAKE_CURRENT_SOURCE_DIR}/DoxygenLayout.xml
-            ${CMAKE_CURRENT_SOURCE_DIR}/MANUAL.dox
-         DESTINATION
-            ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    add_custom_target(doc ALL
-            ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            COMMENT "Generating API documentation with Doxygen" VERBATIM)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../README.md DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY
+        ${CMAKE_CURRENT_SOURCE_DIR}/DoxygenLayout.xml
+        ${CMAKE_CURRENT_SOURCE_DIR}/MANUAL.dox
+     DESTINATION
+        ${CMAKE_CURRENT_BINARY_DIR}
+)
+add_custom_target(doc ALL
+        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Generating API documentation with Doxygen" VERBATIM)
 
-    include(GNUInstallDirs)
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR})
-
-endif(DOXYGEN_FOUND)
+include(GNUInstallDirs)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/html DESTINATION ${CMAKE_INSTALL_DOCDIR})


### PR DESCRIPTION
This PR contains 3 changes:

- Use `CMAKE_INSTALL_DOCDIR` instead of `share/doc/Tweeny` – [The result stays the same by default](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html) but package maintainers have it easier.
- Don't check `TWEENY_BUILD_DOCUMENTATION` – The sub-directory is only added if `TWEENY_BUILD_DOCUMENTATION` is true.
- Require Doxygen  – When documentation is explicitly requested, it shouldn't silently fail.