### PR TITLE
Updated cmake_required_version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@
 # target that uses tweeny, a simple `target_link_libraries(target tweeny)` is sufficient to set up include and link
 # instructions.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.28)
 cmake_policy(SET CMP0063 NEW)
 project(Tweeny LANGUAGES CXX VERSION 3.2.0)
 


### PR DESCRIPTION
From CMAKE documentation:

**Changed in version 3.27:**
Compatibility with versions of CMake older than 3.5 is deprecated. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_policy.html#version) that do not specify at least 3.5 as their policy version (optionally via ...<max>) will produce a deprecation warning in CMake 3.27 and above.

This minor change removes the deprecated message, has been tested with CMAKE 3.28.1 on Arch Linux.