### PR TITLE
Fixed accuracy in some cases

### DIFF
--- a/include/tween.h
+++ b/include/tween.h
@@ -250,7 +250,7 @@ namespace tweeny {
              * @param suppressCallbacks (Optional) Suppress callbacks registered with tween::onStep()
              * @returns std::tuple<Ts...> with the current tween values.
              */
-            const typename detail::tweentraits<T, Ts...>::valuesType & step(float dp, bool suppressCallbacks = false);
+            //const typename detail::tweentraits<T, Ts...>::valuesType & step(float dp, bool suppressCallbacks = false);
 
             /**
              * @brief Seeks to a specified point in time based on the currentProgress.
@@ -261,7 +261,7 @@ namespace tweeny {
              * @param suppressCallbacks (Optional) Suppress callbacks registered with tween::onSeek()
              * @returns std::tuple<Ts...> with the current tween values.
              */
-            const typename detail::tweentraits<T, Ts...>::valuesType & seek(float p, bool suppressCallbacks = false);
+            //const typename detail::tweentraits<T, Ts...>::valuesType & seek(float p, bool suppressCallbacks = false);
 
             /**
              * @brief Seeks to a specified point in time.
@@ -285,7 +285,8 @@ namespace tweeny {
              * @returns std::tuple<Ts...> with the current tween values.
              * @see duration
              */
-            const typename detail::tweentraits<T, Ts...>::valuesType & seek(uint32_t d, bool suppressCallbacks = false);
+            const typename detail::tweentraits<T, Ts...>::valuesType &seek(
+                uint32_t d, bool suppressCallbacks = false);
 
             /**
              * @brief Adds a callback that will be called when stepping occurs, accepting both the tween and
@@ -507,12 +508,26 @@ namespace tweeny {
             const typename detail::tweentraits<T, Ts...>::valuesType peek(uint32_t time) const;
 
             /**
+             * @brief Returns the current time point of the interpolation.
+             *
+             * @returns the current timr point between 0 and total time point (inclusive)
+             */
+            uint32_t currentTimePoint() const; ///< @sa tween::currenttimepoint
+
+            /**
              * @brief Returns the current currentProgress of the interpolation.
              *
              * 0 means its at the values passed in the construction, 1 means the last step.
              * @returns the current currentProgress between 0 and 1 (inclusive)
              */
             float progress() const;
+
+            /**
+             * @brief Returns true if tween reach to end of interpolation progress.
+             *
+             * @returns True means its finished, false means its in progress.
+             */
+            bool isFinished() const;
 
             /**
              * @brief Sets the direction of this tween forward.
@@ -564,7 +579,7 @@ namespace tweeny {
         private /* member variables */:
             uint32_t total = 0; // total runtime
             uint16_t currentPoint = 0; // current point
-            float currentProgress = 0; // current progress
+            uint32_t currentProgress = 0; // current progress
             std::vector<detail::tweenpoint<T, Ts...>> points;
             typename traits::valuesType current;
             std::vector<typename traits::callbackType> onStepCallbacks;
@@ -574,11 +589,18 @@ namespace tweeny {
         private:
             /* member functions */
             tween(T t, Ts... vs);
-            template<size_t I> void interpolate(float prog, unsigned point, typename traits::valuesType & values, detail::int2type<I>) const;
-            void interpolate(float prog, unsigned point, typename traits::valuesType & values, detail::int2type<0>) const;
-            void render(float p);
+            template<size_t I>
+            void interpolate(uint32_t prog,
+                             unsigned point,
+                             typename traits::valuesType &values,
+                             detail::int2type<I>) const;
+            void interpolate(uint32_t prog,
+                             unsigned point,
+                             typename traits::valuesType &values,
+                             detail::int2type<0>) const;
+            void render(uint32_t p);
             void dispatch(std::vector<typename traits::callbackType> & cbVector);
-            uint16_t pointAt(float progress) const;
+            uint16_t pointAt(uint32_t progress) const;
     };
 
     /**
@@ -607,8 +629,10 @@ namespace tweeny {
             template<typename... Ds> tween<T> & during(Ds... ds); ///< @sa tween::during
             const T & step(int32_t dt, bool suppressCallbacks = false); ///< @sa tween::step(int32_t dt, bool suppressCallbacks)
             const T & step(uint32_t dt, bool suppressCallbacks = false); ///< @sa tween::step(uint32_t dt, bool suppressCallbacks)
-            const T & step(float dp, bool suppressCallbacks = false); ///< @sa tween::step(float dp, bool suppressCallbacks)
-            const T & seek(float p, bool suppressCallbacks = false); ///< @sa tween::seek(float p, bool suppressCallbacks)
+            const T &step(float dp,
+                          bool suppressCallbacks
+                          = false); ///< @sa tween::step(float dp, bool suppressCallbacks)
+            //const T & seek(float p, bool suppressCallbacks = false); ///< @sa tween::seek(float p, bool suppressCallbacks)
             const T & seek(int32_t d, bool suppressCallbacks = false); ///< @sa tween::seek(int32_t d, bool suppressCallbacks)
             const T & seek(uint32_t d, bool suppressCallbacks = false); ///< @sa tween::seek(uint32_t d, bool suppressCallbacks)
             tween<T> & onStep(typename detail::tweentraits<T>::callbackType callback); ///< @sa tween::onStep
@@ -621,7 +645,9 @@ namespace tweeny {
             T peek(float progress) const; ///< @sa tween::peek
             T peek(uint32_t time) const; ///< @sa tween::peek
             uint32_t duration() const; ///< @sa tween::duration
-            float progress() const; ///< @sa tween::progress
+            uint32_t currentTimePoint() const; ///< @sa tween::currenttimepoint
+            float progress() const;            ///< @sa tween::progress
+            bool isFinished() const;           ///< @sa tween::isFinished
             tween<T> & forward(); ///< @sa tween::forward
             tween<T> & backward(); ///< @sa tween::backward
             int direction() const; ///< @sa tween::direction
@@ -634,7 +660,7 @@ namespace tweeny {
         private /* member variables */:
             uint32_t total = 0; // total runtime
             uint16_t currentPoint = 0; // current point
-            float currentProgress = 0; // current progress
+            uint32_t currentProgress = 0; // current progress
             std::vector<detail::tweenpoint<T>> points;
             T current;
             std::vector<typename traits::callbackType> onStepCallbacks;
@@ -644,10 +670,10 @@ namespace tweeny {
         private:
             /* member functions */
             tween(T t);
-            void interpolate(float prog, unsigned point, T & value) const;
-            void render(float p);
+            void interpolate(uint32_t prog, unsigned point, T &value) const;
+            void render(uint32_t p);
             void dispatch(std::vector<typename traits::callbackType> & cbVector);
-            uint16_t pointAt(float progress) const;
+            uint16_t pointAt(uint32_t progress) const;
     };
 }
 

--- a/include/tween.h
+++ b/include/tween.h
@@ -250,7 +250,8 @@ namespace tweeny {
              * @param suppressCallbacks (Optional) Suppress callbacks registered with tween::onStep()
              * @returns std::tuple<Ts...> with the current tween values.
              */
-            //const typename detail::tweentraits<T, Ts...>::valuesType & step(float dp, bool suppressCallbacks = false);
+            const typename detail::tweentraits<T, Ts...>::valuesType &step(
+                float dp, bool suppressCallbacks = false);
 
             /**
              * @brief Seeks to a specified point in time based on the currentProgress.
@@ -261,7 +262,8 @@ namespace tweeny {
              * @param suppressCallbacks (Optional) Suppress callbacks registered with tween::onSeek()
              * @returns std::tuple<Ts...> with the current tween values.
              */
-            //const typename detail::tweentraits<T, Ts...>::valuesType & seek(float p, bool suppressCallbacks = false);
+            const typename detail::tweentraits<T, Ts...>::valuesType &seek(
+                float p, bool suppressCallbacks = false);
 
             /**
              * @brief Seeks to a specified point in time.
@@ -632,7 +634,9 @@ namespace tweeny {
             const T &step(float dp,
                           bool suppressCallbacks
                           = false); ///< @sa tween::step(float dp, bool suppressCallbacks)
-            //const T & seek(float p, bool suppressCallbacks = false); ///< @sa tween::seek(float p, bool suppressCallbacks)
+            const T &seek(float p,
+                          bool suppressCallbacks
+                          = false); ///< @sa tween::seek(float p, bool suppressCallbacks)
             const T & seek(int32_t d, bool suppressCallbacks = false); ///< @sa tween::seek(int32_t d, bool suppressCallbacks)
             const T & seek(uint32_t d, bool suppressCallbacks = false); ///< @sa tween::seek(uint32_t d, bool suppressCallbacks)
             tween<T> & onStep(typename detail::tweentraits<T>::callbackType callback); ///< @sa tween::onStep

--- a/include/tween.h
+++ b/include/tween.h
@@ -250,8 +250,7 @@ namespace tweeny {
              * @param suppressCallbacks (Optional) Suppress callbacks registered with tween::onStep()
              * @returns std::tuple<Ts...> with the current tween values.
              */
-            const typename detail::tweentraits<T, Ts...>::valuesType &step(
-                float dp, bool suppressCallbacks = false);
+            const typename detail::tweentraits<T, Ts...>::valuesType & step(float dp, bool suppressCallbacks = false);
 
             /**
              * @brief Seeks to a specified point in time based on the currentProgress.
@@ -262,8 +261,7 @@ namespace tweeny {
              * @param suppressCallbacks (Optional) Suppress callbacks registered with tween::onSeek()
              * @returns std::tuple<Ts...> with the current tween values.
              */
-            const typename detail::tweentraits<T, Ts...>::valuesType &seek(
-                float p, bool suppressCallbacks = false);
+            const typename detail::tweentraits<T, Ts...>::valuesType & seek(float p, bool suppressCallbacks = false);
 
             /**
              * @brief Seeks to a specified point in time.
@@ -287,8 +285,7 @@ namespace tweeny {
              * @returns std::tuple<Ts...> with the current tween values.
              * @see duration
              */
-            const typename detail::tweentraits<T, Ts...>::valuesType &seek(
-                uint32_t d, bool suppressCallbacks = false);
+            const typename detail::tweentraits<T, Ts...>::valuesType & seek(uint32_t d, bool suppressCallbacks = false);
 
             /**
              * @brief Adds a callback that will be called when stepping occurs, accepting both the tween and
@@ -591,15 +588,8 @@ namespace tweeny {
         private:
             /* member functions */
             tween(T t, Ts... vs);
-            template<size_t I>
-            void interpolate(uint32_t prog,
-                             unsigned point,
-                             typename traits::valuesType &values,
-                             detail::int2type<I>) const;
-            void interpolate(uint32_t prog,
-                             unsigned point,
-                             typename traits::valuesType &values,
-                             detail::int2type<0>) const;
+            template<size_t I> void interpolate(uint32_t prog, unsigned point, typename traits::valuesType & values, detail::int2type<I>) const;
+            void interpolate(uint32_t prog, unsigned point, typename traits::valuesType & values, detail::int2type<0>) const;
             void render(uint32_t p);
             void dispatch(std::vector<typename traits::callbackType> & cbVector);
             uint16_t pointAt(uint32_t progress) const;
@@ -631,12 +621,8 @@ namespace tweeny {
             template<typename... Ds> tween<T> & during(Ds... ds); ///< @sa tween::during
             const T & step(int32_t dt, bool suppressCallbacks = false); ///< @sa tween::step(int32_t dt, bool suppressCallbacks)
             const T & step(uint32_t dt, bool suppressCallbacks = false); ///< @sa tween::step(uint32_t dt, bool suppressCallbacks)
-            const T &step(float dp,
-                          bool suppressCallbacks
-                          = false); ///< @sa tween::step(float dp, bool suppressCallbacks)
-            const T &seek(float p,
-                          bool suppressCallbacks
-                          = false); ///< @sa tween::seek(float p, bool suppressCallbacks)
+            const T & step(float dp, bool suppressCallbacks = false); ///< @sa tween::step(float dp, bool suppressCallbacks)
+            const T & seek(float p, bool suppressCallbacks = false); ///< @sa tween::seek(float p, bool suppressCallbacks)
             const T & seek(int32_t d, bool suppressCallbacks = false); ///< @sa tween::seek(int32_t d, bool suppressCallbacks)
             const T & seek(uint32_t d, bool suppressCallbacks = false); ///< @sa tween::seek(uint32_t d, bool suppressCallbacks)
             tween<T> & onStep(typename detail::tweentraits<T>::callbackType callback); ///< @sa tween::onStep
@@ -650,8 +636,8 @@ namespace tweeny {
             T peek(uint32_t time) const; ///< @sa tween::peek
             uint32_t duration() const; ///< @sa tween::duration
             uint32_t currentTimePoint() const; ///< @sa tween::currenttimepoint
-            float progress() const;            ///< @sa tween::progress
-            bool isFinished() const;           ///< @sa tween::isFinished
+            float progress() const; ///< @sa tween::progress
+            bool isFinished() const; ///< @sa tween::isFinished
             tween<T> & forward(); ///< @sa tween::forward
             tween<T> & backward(); ///< @sa tween::backward
             int direction() const; ///< @sa tween::direction
@@ -674,7 +660,7 @@ namespace tweeny {
         private:
             /* member functions */
             tween(T t);
-            void interpolate(uint32_t prog, unsigned point, T &value) const;
+            void interpolate(uint32_t prog, unsigned point, T & value) const;
             void render(uint32_t p);
             void dispatch(std::vector<typename traits::callbackType> & cbVector);
             uint16_t pointAt(uint32_t progress) const;

--- a/include/tween.tcc
+++ b/include/tween.tcc
@@ -199,7 +199,7 @@ namespace tweeny {
 
     template<typename T, typename... Ts>
     inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::seek(int32_t t, bool suppress) {
-        seek(static_cast<uint32_t>(std::abs(t)), suppress);
+        return seek(static_cast<uint32_t>(std::abs(t)), suppress);
     }
 
     template<typename T, typename... Ts>

--- a/include/tween.tcc
+++ b/include/tween.tcc
@@ -178,10 +178,12 @@ namespace tweeny {
         return step(static_cast<int32_t>(dt), suppress);
     }
 
-    // template<typename T, typename... Ts>
-    // inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::step(float dp, bool suppress) {
-
-    // }
+    template<typename T, typename... Ts>
+    inline const typename detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::step(
+        float dp, bool suppress)
+    {
+        return step(static_cast<int32_t>(dp * total), suppress);
+    }
 
     template<typename T, typename... Ts>
     inline const typename detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::seek(
@@ -197,7 +199,14 @@ namespace tweeny {
 
     template<typename T, typename... Ts>
     inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::seek(int32_t t, bool suppress) {
-        seek(static_cast<int32_t>(std::abs(t)), suppress);
+        seek(static_cast<uint32_t>(std::abs(t)), suppress);
+    }
+
+    template<typename T, typename... Ts>
+    inline const detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::seek(float p,
+                                                                                  bool suppress)
+    {
+        return seek(static_cast<int32_t>(p * total), suppress);
     }
 
     template<typename T, typename... Ts>

--- a/include/tween.tcc
+++ b/include/tween.tcc
@@ -202,10 +202,10 @@ namespace tweeny {
         return seek(static_cast<uint32_t>(std::abs(t)), suppress);
     }
 
-    template<typename T, typename... Ts>
-    inline const detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::seek(float p,
-                                                                                  bool suppress)
-    {
+	template<typename T, typename... Ts>
+	inline const typename detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::seek(
+		float p, bool suppress)
+	{
         return seek(static_cast<int32_t>(p * total), suppress);
     }
 

--- a/include/tween.tcc
+++ b/include/tween.tcc
@@ -29,8 +29,9 @@
 #ifndef TWEENY_TWEEN_TCC
 #define TWEENY_TWEEN_TCC
 
-#include "tween.h"
 #include "dispatcher.h"
+#include "tween.h"
+#include <cstdlib>
 
 namespace tweeny {
 
@@ -165,7 +166,11 @@ namespace tweeny {
 
     template<typename T, typename... Ts>
     inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::step(int32_t dt, bool suppress) {
-        return step(static_cast<float>(dt)/static_cast<float>(total), suppress);
+        dt *= currentDirection;
+        seek(currentProgress + dt, true);
+        if (!suppress)
+            dispatch(onStepCallbacks);
+        return current;
     }
 
     template<typename T, typename... Ts>
@@ -173,26 +178,26 @@ namespace tweeny {
         return step(static_cast<int32_t>(dt), suppress);
     }
 
-    template<typename T, typename... Ts>
-    inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::step(float dp, bool suppress) {
-        dp *= currentDirection;
-        seek(currentProgress + dp, true);
-        if (!suppress) dispatch(onStepCallbacks);
-        return current;
-    }
+    // template<typename T, typename... Ts>
+    // inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::step(float dp, bool suppress) {
+
+    // }
 
     template<typename T, typename... Ts>
-    inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::seek(float p, bool suppress) {
-        p = detail::clip(p, 0.0f, 1.0f);
+    inline const typename detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::seek(
+        uint32_t p, bool suppress)
+    {
+        p = detail::clip(p, 0u, total);
         currentProgress = p;
         render(p);
-        if (!suppress) dispatch(onSeekCallbacks);
+        if (!suppress)
+            dispatch(onSeekCallbacks);
         return current;
     }
 
     template<typename T, typename... Ts>
     inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::seek(int32_t t, bool suppress) {
-        return seek(static_cast<float>(t) / static_cast<float>(total), suppress);
+        seek(static_cast<int32_t>(std::abs(t)), suppress);
     }
 
     template<typename T, typename... Ts>
@@ -202,9 +207,13 @@ namespace tweeny {
 
     template<typename T, typename... Ts>
     template<size_t I>
-    inline void tween<T, Ts...>::interpolate(float prog, unsigned point, typename traits::valuesType & values, detail::int2type<I>) const {
+    inline void tween<T, Ts...>::interpolate(uint32_t prog,
+                                             unsigned point,
+                                             typename traits::valuesType &values,
+                                             detail::int2type<I>) const
+    {
         auto & p = points.at(point);
-        auto pointDuration = uint32_t(p.duration() - (p.stacked - (prog * static_cast<float>(total))));
+        auto pointDuration = uint32_t(p.duration() - (p.stacked - prog));
         float pointTotal = static_cast<float>(pointDuration) / static_cast<float>(p.duration(I));
         if (pointTotal > 1.0f) pointTotal = 1.0f;
         auto easing = std::get<I>(p.easings);
@@ -213,9 +222,13 @@ namespace tweeny {
     }
 
     template<typename T, typename... Ts>
-    inline void tween<T, Ts...>::interpolate(float prog, unsigned point, typename traits::valuesType & values, detail::int2type<0>) const {
+    inline void tween<T, Ts...>::interpolate(uint32_t prog,
+                                             unsigned point,
+                                             typename traits::valuesType &values,
+                                             detail::int2type<0>) const
+    {
         auto & p = points.at(point);
-        auto pointDuration = uint32_t(p.duration() - (p.stacked - (prog * static_cast<float>(total))));
+        auto pointDuration = uint32_t(p.duration() - (p.stacked - prog));
         float pointTotal = static_cast<float>(pointDuration) / static_cast<float>(p.duration(0));
         if (pointTotal > 1.0f) pointTotal = 1.0f;
         auto easing = std::get<0>(p.easings);
@@ -223,7 +236,8 @@ namespace tweeny {
     }
 
     template<typename T, typename... Ts>
-    inline void tween<T, Ts...>::render(float p) {
+    inline void tween<T, Ts...>::render(uint32_t p)
+    {
         currentPoint = pointAt(p);
         interpolate(p, currentPoint, current, detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{ });
     }
@@ -290,21 +304,40 @@ namespace tweeny {
     template<typename T, typename... Ts>
     const typename detail::tweentraits<T, Ts...>::valuesType tween<T, Ts...>::peek(float progress) const {
         typename detail::tweentraits<T, Ts...>::valuesType values;
-        interpolate(progress, pointAt(progress), values, detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{ });
+        uint32_t time = progress * total;
+        interpolate(time,
+                    pointAt(time),
+                    values,
+                    detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{});
         return values;
     }
 
     template<typename T, typename... Ts>
     const typename detail::tweentraits<T, Ts...>::valuesType tween<T, Ts...>::peek(uint32_t time) const {
         typename detail::tweentraits<T, Ts...>::valuesType values;
-        float progress = static_cast<float>(time) / static_cast<float>(total);
-        interpolate(progress, pointAt(progress), values, detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{ });
+        interpolate(time,
+                    pointAt(time),
+                    values,
+                    detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{});
         return values;
     }
 
-  template<typename T, typename... Ts>
-    float tween<T, Ts...>::progress() const {
+    template<typename T, typename... Ts>
+    uint32_t tween<T, Ts...>::currentTimePoint() const
+    {
         return currentProgress;
+    }
+
+    template<typename T, typename... Ts>
+    float tween<T, Ts...>::progress() const
+    {
+        return static_cast<float>(currentProgress) / static_cast<float>(total);
+    }
+
+    template<typename T, typename... Ts>
+    bool tween<T, Ts...>::isFinished() const
+    {
+        return currentProgress == total;
     }
 
     template<typename T, typename... Ts>
@@ -334,12 +367,15 @@ namespace tweeny {
         return currentPoint;
     }
 
-    template<typename T, typename... Ts> inline uint16_t tween<T, Ts...>::pointAt(float progress) const {
-        progress = detail::clip(progress, 0.0f, 1.0f);
-        uint32_t t = static_cast<uint32_t>(progress * total);
+    template<typename T, typename... Ts>
+    inline uint16_t tween<T, Ts...>::pointAt(uint32_t progress) const
+    {
+        progress = detail::clip(progress, 0u, total);
         uint16_t point = 0;
-        while (t > points.at(point).stacked) point++;
-        if (point > 0 && t <= points.at(point - 1u).stacked) point--;
+        while (progress > points.at(point).stacked)
+            point++;
+        if (point > 0 && progress <= points.at(point - 1u).stacked)
+            point--;
         return point;
     }
 }

--- a/include/tween.tcc
+++ b/include/tween.tcc
@@ -29,9 +29,8 @@
 #ifndef TWEENY_TWEEN_TCC
 #define TWEENY_TWEEN_TCC
 
-#include "dispatcher.h"
 #include "tween.h"
-#include <cstdlib>
+#include "dispatcher.h"
 
 namespace tweeny {
 
@@ -179,21 +178,16 @@ namespace tweeny {
     }
 
     template<typename T, typename... Ts>
-    inline const typename detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::step(
-        float dp, bool suppress)
-    {
+    inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::step(float dp, bool suppress) {
         return step(static_cast<int32_t>(dp * total), suppress);
     }
 
     template<typename T, typename... Ts>
-    inline const typename detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::seek(
-        uint32_t p, bool suppress)
-    {
+    inline const typename detail::tweentraits<T, Ts...>::valuesType & tween<T, Ts...>::seek(uint32_t p, bool suppress) {
         p = detail::clip(p, 0u, total);
         currentProgress = p;
         render(p);
-        if (!suppress)
-            dispatch(onSeekCallbacks);
+        if (!suppress) dispatch(onSeekCallbacks);
         return current;
     }
 
@@ -203,9 +197,7 @@ namespace tweeny {
     }
 
 	template<typename T, typename... Ts>
-	inline const typename detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::seek(
-		float p, bool suppress)
-	{
+	inline const typename detail::tweentraits<T, Ts...>::valuesType &tween<T, Ts...>::seek(float p, bool suppress) {
         return seek(static_cast<int32_t>(p * total), suppress);
     }
 
@@ -216,11 +208,7 @@ namespace tweeny {
 
     template<typename T, typename... Ts>
     template<size_t I>
-    inline void tween<T, Ts...>::interpolate(uint32_t prog,
-                                             unsigned point,
-                                             typename traits::valuesType &values,
-                                             detail::int2type<I>) const
-    {
+    inline void tween<T, Ts...>::interpolate(uint32_t prog, unsigned point, typename traits::valuesType & values, detail::int2type<I>) const {
         auto & p = points.at(point);
         auto pointDuration = uint32_t(p.duration() - (p.stacked - prog));
         float pointTotal = static_cast<float>(pointDuration) / static_cast<float>(p.duration(I));
@@ -231,11 +219,7 @@ namespace tweeny {
     }
 
     template<typename T, typename... Ts>
-    inline void tween<T, Ts...>::interpolate(uint32_t prog,
-                                             unsigned point,
-                                             typename traits::valuesType &values,
-                                             detail::int2type<0>) const
-    {
+    inline void tween<T, Ts...>::interpolate(uint32_t prog, unsigned point, typename traits::valuesType & values, detail::int2type<0>) const {
         auto & p = points.at(point);
         auto pointDuration = uint32_t(p.duration() - (p.stacked - prog));
         float pointTotal = static_cast<float>(pointDuration) / static_cast<float>(p.duration(0));
@@ -245,8 +229,7 @@ namespace tweeny {
     }
 
     template<typename T, typename... Ts>
-    inline void tween<T, Ts...>::render(uint32_t p)
-    {
+    inline void tween<T, Ts...>::render(uint32_t p) {
         currentPoint = pointAt(p);
         interpolate(p, currentPoint, current, detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{ });
     }
@@ -314,38 +297,29 @@ namespace tweeny {
     const typename detail::tweentraits<T, Ts...>::valuesType tween<T, Ts...>::peek(float progress) const {
         typename detail::tweentraits<T, Ts...>::valuesType values;
         uint32_t time = progress * total;
-        interpolate(time,
-                    pointAt(time),
-                    values,
-                    detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{});
+        interpolate(time, pointAt(time), values, detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{ });
         return values;
     }
 
     template<typename T, typename... Ts>
     const typename detail::tweentraits<T, Ts...>::valuesType tween<T, Ts...>::peek(uint32_t time) const {
         typename detail::tweentraits<T, Ts...>::valuesType values;
-        interpolate(time,
-                    pointAt(time),
-                    values,
-                    detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{});
+        interpolate(time, pointAt(time), values, detail::int2type<sizeof...(Ts) - 1 + 1 /* +1 for the T */>{ });
         return values;
     }
 
     template<typename T, typename... Ts>
-    uint32_t tween<T, Ts...>::currentTimePoint() const
-    {
+    uint32_t tween<T, Ts...>::currentTimePoint() const {
         return currentProgress;
     }
 
     template<typename T, typename... Ts>
-    float tween<T, Ts...>::progress() const
-    {
+    float tween<T, Ts...>::progress() const {
         return static_cast<float>(currentProgress) / static_cast<float>(total);
     }
 
     template<typename T, typename... Ts>
-    bool tween<T, Ts...>::isFinished() const
-    {
+    bool tween<T, Ts...>::isFinished() const {
         return currentProgress == total;
     }
 
@@ -376,15 +350,11 @@ namespace tweeny {
         return currentPoint;
     }
 
-    template<typename T, typename... Ts>
-    inline uint16_t tween<T, Ts...>::pointAt(uint32_t progress) const
-    {
+    template<typename T, typename... Ts> inline uint16_t tween<T, Ts...>::pointAt(uint32_t progress) const {
         progress = detail::clip(progress, 0u, total);
         uint16_t point = 0;
-        while (progress > points.at(point).stacked)
-            point++;
-        if (point > 0 && progress <= points.at(point - 1u).stacked)
-            point--;
+        while (progress > points.at(point).stacked) point++;
+        if (point > 0 && progress <= points.at(point - 1u).stacked) point--;
         return point;
     }
 }

--- a/include/tweenone.tcc
+++ b/include/tweenone.tcc
@@ -159,8 +159,7 @@ namespace tweeny {
     inline const T & tween<T>::step(int32_t dt, bool suppress) {
         dt *= currentDirection;
         seek(currentProgress + dt, true);
-        if (!suppress)
-            dispatch(onStepCallbacks);
+        if (!suppress) dispatch(onStepCallbacks);
         return current;
     }
 
@@ -170,14 +169,12 @@ namespace tweeny {
     }
 
     template<typename T>
-    inline const T &tween<T>::step(float dp, bool suppress)
-    {
+    inline const T & tween<T>::step(float dp, bool suppress) {
         return step(static_cast<int32_t>(dp * total), suppress);
     }
 
     template<typename T>
-    inline const T &tween<T>::seek(float p, bool suppress)
-    {
+    inline const T & tween<T>::seek(float p, bool suppress) {
         return seek(static_cast<int32_t>(p * total), suppress);
     }
 
@@ -186,8 +183,7 @@ namespace tweeny {
         t = detail::clip(t, 0, (int32_t) total);
         currentProgress = t;
         render(t);
-        if (!suppress)
-            dispatch(onSeekCallbacks);
+        if (!suppress) dispatch(onSeekCallbacks);
         return current;
     }
 
@@ -202,8 +198,7 @@ namespace tweeny {
     }
 
     template<typename T>
-    inline void tween<T>::interpolate(uint32_t prog, unsigned point, T &value) const
-    {
+    inline void tween<T>::interpolate(uint32_t prog, unsigned point, T & value) const {
         auto & p = points.at(point);
         auto pointDuration = uint32_t(p.duration() - (p.stacked - prog));
         float pointTotal = static_cast<float>(pointDuration) / static_cast<float>(p.duration());
@@ -213,8 +208,7 @@ namespace tweeny {
     }
 
     template<typename T>
-    inline void tween<T>::render(uint32_t p)
-    {
+    inline void tween<T>::render(uint32_t p) {
         currentPoint = pointAt(p);
         interpolate(p, currentPoint, current);
     }
@@ -294,26 +288,22 @@ namespace tweeny {
     }
 
     template<typename T>
-    uint32_t tween<T>::currentTimePoint() const
-    {
+    uint32_t tween<T>::currentTimePoint() const {
         return currentProgress;
     }
 
     template<typename T>
-    float tween<T>::progress() const
-    {
+    float tween<T>::progress() const {
         return static_cast<float>(currentProgress) / static_cast<float>(total);
     }
 
     template<typename T>
-    bool tween<T>::isFinished() const
-    {
+    bool tween<T>::isFinished() const {
         return currentProgress == total;
     }
 
     template<typename T>
-    tween<T> &tween<T>::forward()
-    {
+    tween<T> & tween<T>::forward() {
         currentDirection = 1;
         return *this;
     }
@@ -339,9 +329,7 @@ namespace tweeny {
         return currentPoint;
     }
 
-    template<typename T>
-    inline uint16_t tween<T>::pointAt(uint32_t timePoint) const
-    {
+    template<typename T> inline uint16_t tween<T>::pointAt(uint32_t timePoint) const {
         timePoint = detail::clip(timePoint, 0u, total);
         auto t = static_cast<uint32_t>(timePoint);
         uint16_t point = 0;

--- a/include/tweenone.tcc
+++ b/include/tweenone.tcc
@@ -157,7 +157,11 @@ namespace tweeny {
 
     template<typename T>
     inline const T & tween<T>::step(int32_t dt, bool suppress) {
-        return step(static_cast<float>(dt)/static_cast<float>(total), suppress);
+        dt *= currentDirection;
+        seek(currentProgress + dt, true);
+        if (!suppress)
+            dispatch(onStepCallbacks);
+        return current;
     }
 
     template<typename T>
@@ -166,30 +170,29 @@ namespace tweeny {
     }
 
     template<typename T>
-    inline const T & tween<T>::step(float dp, bool suppress) {
-        dp *= currentDirection;
-        seek(currentProgress + dp, true);
-        if (!suppress) dispatch(onStepCallbacks);
-        return current;
+    inline const T &tween<T>::step(float dp, bool suppress)
+    {
+        return step(static_cast<int32_t>(dp * total), suppress);
     }
 
-    template<typename T>
-    inline const T & tween<T>::seek(float p, bool suppress) {
-        p = detail::clip(p, 0.0f, 1.0f);
-        currentProgress = p;
-        render(p);
-        if (!suppress) dispatch(onSeekCallbacks);
-        return current;
-    }
+    // template<typename T>
+    // inline const T & tween<T>::seek(float p, bool suppress) {
+
+    // }
 
     template<typename T>
     inline const T & tween<T>::seek(int32_t t, bool suppress) {
-        return seek(static_cast<float>(t) / static_cast<float>(total), suppress);
+        t = detail::clip(t, 0, (int32_t) total);
+        currentProgress = t;
+        render(t);
+        if (!suppress)
+            dispatch(onSeekCallbacks);
+        return current;
     }
 
     template<typename T>
     inline const T & tween<T>::seek(uint32_t t, bool suppress) {
-        return seek(static_cast<float>(t) / static_cast<float>(total), suppress);
+        return seek(static_cast<int32_t>(t), suppress);
     }
 
     template<typename T>
@@ -198,9 +201,10 @@ namespace tweeny {
     }
 
     template<typename T>
-    inline void tween<T>::interpolate(float prog, unsigned point, T & value) const {
+    inline void tween<T>::interpolate(uint32_t prog, unsigned point, T &value) const
+    {
         auto & p = points.at(point);
-        auto pointDuration = uint32_t(p.duration() - (p.stacked - (prog * static_cast<float>(total))));
+        auto pointDuration = uint32_t(p.duration() - (p.stacked - prog));
         float pointTotal = static_cast<float>(pointDuration) / static_cast<float>(p.duration());
         if (pointTotal > 1.0f) pointTotal = 1.0f;
         auto easing = std::get<0>(p.easings);
@@ -208,7 +212,8 @@ namespace tweeny {
     }
 
     template<typename T>
-    inline void tween<T>::render(float p) {
+    inline void tween<T>::render(uint32_t p)
+    {
         currentPoint = pointAt(p);
         interpolate(p, currentPoint, current);
     }
@@ -288,14 +293,27 @@ namespace tweeny {
         return value;
     }
 
-
-  template<typename T>
-    float tween<T>::progress() const {
+    template<typename T>
+    uint32_t tween<T>::currentTimePoint() const
+    {
         return currentProgress;
     }
 
     template<typename T>
-    tween<T> & tween<T>::forward() {
+    float tween<T>::progress() const
+    {
+        return static_cast<float>(currentProgress) / static_cast<float>(total);
+    }
+
+    template<typename T>
+    bool tween<T>::isFinished() const
+    {
+        return currentProgress == total;
+    }
+
+    template<typename T>
+    tween<T> &tween<T>::forward()
+    {
         currentDirection = 1;
         return *this;
     }
@@ -321,11 +339,11 @@ namespace tweeny {
         return currentPoint;
     }
 
-
-
-    template<typename T> inline uint16_t tween<T>::pointAt(float progress) const {
-        progress = detail::clip(progress, 0.0f, 1.0f);
-        auto t = static_cast<uint32_t>(progress * total);
+    template<typename T>
+    inline uint16_t tween<T>::pointAt(uint32_t timePoint) const
+    {
+        timePoint = detail::clip(timePoint, 0u, total);
+        auto t = static_cast<uint32_t>(timePoint);
         uint16_t point = 0;
         while (t > points.at(point).stacked) point++;
         if (point > 0 && t <= points.at(point - 1u).stacked) point--;

--- a/include/tweenone.tcc
+++ b/include/tweenone.tcc
@@ -175,10 +175,11 @@ namespace tweeny {
         return step(static_cast<int32_t>(dp * total), suppress);
     }
 
-    // template<typename T>
-    // inline const T & tween<T>::seek(float p, bool suppress) {
-
-    // }
+    template<typename T>
+    inline const T &tween<T>::seek(float p, bool suppress)
+    {
+        return seek(static_cast<int32_t>(p * total), suppress);
+    }
 
     template<typename T>
     inline const T & tween<T>::seek(int32_t t, bool suppress) {
@@ -281,15 +282,14 @@ namespace tweeny {
     template<typename T>
     T tween<T>::peek(float progress) const {
         T value;
-        interpolate(progress, pointAt(progress), value);
+        interpolate(progress * total, pointAt(progress * total), value);
         return value;
     }
 
     template<typename T>
     T tween<T>::peek(uint32_t time) const {
         T value;
-        float progress = static_cast<float>(time) / static_cast<float>(total);
-        interpolate(progress, pointAt(progress), value);
+        interpolate(time, pointAt(time), value);
         return value;
     }
 


### PR DESCRIPTION
Also, it's improved with removing dividing and multiplying with "total"  in every step.

It will be fixed incorrect result in the following example:

`    auto tween = tweeny::from(1.0f, 1.0f)`
`                     .to(7.0f, 7.0f)`
`                     .during(60)`
`                     .via(tweeny::easing::enumerated::linear)`
`                     .onStep([](float i, float f) {`
`                         printf("running: i=%f f=%f\n", i, f);`
`                         fflush(stdout);`
`                         return false;`
`                     });`
`    while (tween.progress() < 1.0f) {`
`        auto [value1, value2] = tween.peek(tween.progress());`
`        printf(" progress:%f and values is: %f,%f\n", tween.progress(), value1, value2);`
`        fflush(stdout);`
`        tween.step(10);`
`    }`
`    fflush(stdout);`
`    tween.backward();`
`    while (tween.progress() > 0.0f) {`
`        auto [value1, value2] = tween.peek(tween.progress());`
`        printf(" progress:%f and values is: %f,%f\n", tween.progress(), value1, value2);`
`        fflush(stdout);`
`        tween.step(10);`
`    }`
`    auto [value1, value2] = tween.peek(tween.progress());`
`    printf(" progress:%f and values is: %f,%f\n", tween.progress(), value1, value2);`

I get following result on Ubuntu 22.04 with gcc-11 without this commit:

 progress:0.000000 and values is: 1.000000,1.000000
running: i=2.000000 f=2.000000
 progress:0.166667 and values is: 2.000000,2.000000
running: i=3.000000 f=3.000000
 progress:0.333333 and values is: 3.000000,3.000000
running: i=4.000000 f=4.000000
 progress:0.500000 and values is: 4.000000,4.000000
running: i=5.000000 f=5.000000
 progress:0.666667 and values is: 5.000000,5.000000
running: i=6.000000 f=6.000000
 progress:0.833333 and values is: 6.000000,6.000000
running: i=7.000000 f=7.000000
 progress:1.000000 and values is: 7.000000,7.000000
running: i=6.000000 f=6.000000
 progress:0.833333 and values is: 6.000000,6.000000
running: i=4.900000 f=4.900000
 progress:0.666667 and values is: 4.900000,4.900000
running: i=3.900000 f=3.900000
 progress:0.500000 and values is: 3.900000,3.900000
running: i=2.900000 f=2.900000
 progress:0.333333 and values is: 2.900000,2.900000
running: i=1.900000 f=1.900000
 progress:0.166667 and values is: 1.900000,1.900000
running: i=1.000000 f=1.000000
 progress:0.000000 and values is: 1.000000,1.000000

but it must be:

 progress:0.000000 and values is: 1.000000,1.000000
running: i=2.000000 f=2.000000
 progress:0.166667 and values is: 2.000000,2.000000
running: i=3.000000 f=3.000000
 progress:0.333333 and values is: 3.000000,3.000000
running: i=4.000000 f=4.000000
 progress:0.500000 and values is: 4.000000,4.000000
running: i=5.000000 f=5.000000
 progress:0.666667 and values is: 5.000000,5.000000
running: i=6.000000 f=6.000000
 progress:0.833333 and values is: 6.000000,6.000000
running: i=7.000000 f=7.000000
 progress:1.000000 and values is: 7.000000,7.000000
running: i=6.000000 f=6.000000
 progress:0.833333 and values is: 6.000000,6.000000
running: i=5.000000 f=5.000000
 progress:0.666667 and values is: 5.000000,5.000000
running: i=4.000000 f=4.000000
 progress:0.500000 and values is: 4.000000,4.000000
running: i=3.000000 f=3.000000
 progress:0.333333 and values is: 3.000000,3.000000
running: i=2.000000 f=2.000000
 progress:0.166667 and values is: 2.000000,2.000000
running: i=1.000000 f=1.000000
 progress:0.000000 and values is: 1.000000,1.000000

The result of direct stepping and backward stepping is different! And I think there are many similar cases. And I think extra divining and multiplying can be removed.
Please check my commit.